### PR TITLE
Drop GAME & PLAY token to all ZERO holders

### DIFF
--- a/bin/zero/runtime/src/lib.rs
+++ b/bin/zero/runtime/src/lib.rs
@@ -1434,6 +1434,9 @@ impl gamedao_treasury::Config for Runtime {
 
 impl zero_migration::Config for Runtime {
 	type Event = Event;
+	type PaymentTokenId = PlayCurrencyId;
+	type ProtocolTokenId = GameCurrencyId;
+
 }
 
 construct_runtime!(

--- a/bin/zero/runtime/src/lib.rs
+++ b/bin/zero/runtime/src/lib.rs
@@ -1436,7 +1436,7 @@ impl zero_migration::Config for Runtime {
 	type Event = Event;
 	type PaymentTokenId = PlayCurrencyId;
 	type ProtocolTokenId = GameCurrencyId;
-
+	type ModuleAccounts = DustRemovalWhitelist;
 }
 
 construct_runtime!(

--- a/bin/zero/runtime/src/lib.rs
+++ b/bin/zero/runtime/src/lib.rs
@@ -124,7 +124,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to 0. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 52,
+	spec_version: 54,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/migration/migration/Cargo.toml
+++ b/migration/migration/Cargo.toml
@@ -24,6 +24,7 @@ frame-system = { git = "https://github.com/paritytech/substrate", default-featur
 frame-benchmarking = { git = "https://github.com/paritytech/substrate",  default-features = false , optional = true , branch = "polkadot-v0.9.13" }
 pallet-identity = { default-features = false, path = "../identity" }
 pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.13" }
+orml-tokens = { path = "../../orml/tokens", default-features = false }
 sp-std = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.13" }
 sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.13" }
 sp-io = { git = "https://github.com/paritytech/substrate",  default-features = false , branch = "polkadot-v0.9.13" }
@@ -33,6 +34,8 @@ sp-core = { git = "https://github.com/paritytech/substrate", default-features = 
 [dev-dependencies]
 hex = "0.4.3"
 rand = "0.8.5"
+orml-currencies = { path = "../../orml/currencies", default-features = false }
+orml-traits = { path = "../../orml/traits", default-features = false }
 
 [features]
 default = ["std"]
@@ -42,5 +45,6 @@ std = [
 	"frame-support/std",
 	"frame-system/std",
 	"pallet-identity/std",
-	"pallet-balances/std"
+	"pallet-balances/std",
+	"orml-tokens/std"
 ]

--- a/migration/migration/Cargo.toml
+++ b/migration/migration/Cargo.toml
@@ -34,7 +34,6 @@ sp-core = { git = "https://github.com/paritytech/substrate", default-features = 
 [dev-dependencies]
 hex = "0.4.3"
 rand = "0.8.5"
-orml-currencies = { path = "../../orml/currencies", default-features = false }
 orml-traits = { path = "../../orml/traits", default-features = false }
 
 [features]

--- a/migration/migration/src/lib.rs
+++ b/migration/migration/src/lib.rs
@@ -133,10 +133,10 @@ pub mod pallet {
 			}
 			let mut accounts: u32 = 0;
 
-			// for (acc_id, acc_info) in pallet_balances::Account::<T>::iter() {			     // --> contains no accounts
-			// for (acc_id, acc_info) in <T as pallet_balances::Config>::AccountStore::iter() {  // --> no iterator
+			// for (acc_id, acc_info) in pallet_balances::Account::<T>::iter() {				// --> contains no accounts
+			// for (acc_id, acc_info) in <T as pallet_balances::Config>::AccountStore::iter() {	// --> no iterator
 			for (acc_id, _acc_info) in <frame_system::Account::<T>>::iter() {				
-				// let bal: u128 = acc_info.data.free.saturated_into();							 // --> no field `free` on type `AccountData`
+				// let bal: u128 = acc_info.data.free.saturated_into();							// --> no field `free` on type `AccountData`
 				let bal: u128 = <T as pallet_balances::Config>::AccountStore::get(&acc_id).free.saturated_into();
 				let balance: <T as orml_tokens::Config>::Balance = bal.saturated_into();
 				
@@ -153,7 +153,7 @@ pub mod pallet {
 			}
 			<TokensVersion<T>>::set(StorageVersion::V2Imported);
 
-			Self::deposit_event(Event::<T>::TokensAirDropped(accounts) );
+			Self::deposit_event(Event::<T>::TokensAirDropped(accounts));
 
 			Ok(())
 		}

--- a/migration/migration/src/lib.rs
+++ b/migration/migration/src/lib.rs
@@ -133,10 +133,8 @@ pub mod pallet {
 			}
 			let mut accounts: u32 = 0;
 
-			// for (acc_id, acc_info) in pallet_balances::Account::<T>::iter() {				// --> contains no accounts
-			// for (acc_id, acc_info) in <T as pallet_balances::Config>::AccountStore::iter() {	// --> no iterator
 			for (acc_id, _acc_info) in <frame_system::Account::<T>>::iter() {				
-				// let bal: u128 = acc_info.data.free.saturated_into();							// --> no field `free` on type `AccountData`
+				// let bal: u128 = acc_info.data.free.saturated_into();	// --> no field `free` on type `AccountData`
 				let bal: u128 = <T as pallet_balances::Config>::AccountStore::get(&acc_id).free.saturated_into();
 				let balance: <T as orml_tokens::Config>::Balance = bal.saturated_into();
 				

--- a/migration/migration/src/lib.rs
+++ b/migration/migration/src/lib.rs
@@ -159,7 +159,7 @@ pub mod pallet {
 			}
 			<TokensVersion<T>>::set(StorageVersion::V2Imported);
 
-			// Self::deposit_event(Event::<T>::TokensAirDropped(1_u32));
+			Self::deposit_event(Event::<T>::TokensAirDropped(accounts));
 
 			Ok(())
 		}

--- a/migration/migration/src/lib.rs
+++ b/migration/migration/src/lib.rs
@@ -129,7 +129,6 @@ pub mod pallet {
 		/// Set Tokens (GAME & PLAY) balances with the same amount as native currency has
 		#[pallet::weight(5_000_000)]
 		pub fn tokens_airdrop(origin: OriginFor<T>) -> DispatchResult {
-			Self::deposit_event(Event::<T>::TokensAirDropped(1_u32));
 			ensure_root(origin.clone())?;
 
 			if <TokensVersion<T>>::get() == StorageVersion::V2Imported {

--- a/migration/migration/src/mock.rs
+++ b/migration/migration/src/mock.rs
@@ -36,6 +36,7 @@ pub const PAYMENT_TOKEN_ID: CurrencyId = 2;
 pub const ALICE: AccountId = 1;
 pub const BOB: AccountId = 2;
 pub const DAVE: AccountId = 3;
+pub const TREASURY: AccountId = 4;
 
 mod zero_migration {
 	pub use super::super::*;
@@ -134,10 +135,18 @@ frame_support::parameter_types! {
 	pub const PaymentTokenId: CurrencyId = PAYMENT_TOKEN_ID;
 }
 
+pub struct ModuleAccounts;
+impl Contains<AccountId> for ModuleAccounts {
+	fn contains(a: &AccountId) -> bool {
+		vec![TREASURY].contains(a)
+	}
+}
+
 impl Config for Test {
 	type Event = Event;
 	type PaymentTokenId = PaymentTokenId;
 	type ProtocolTokenId = ProtocolTokenId;
+	type ModuleAccounts = ModuleAccounts;
 }
 
 construct_runtime!(

--- a/migration/migration/src/mock.rs
+++ b/migration/migration/src/mock.rs
@@ -1,0 +1,187 @@
+#![cfg(test)]
+
+pub use super::*;
+use frame_support::{
+	construct_runtime, parameter_types, ord_parameter_types,
+	traits::{Everything, GenesisBuild, Nothing},
+};
+use frame_system::{EnsureOneOf, EnsureRoot, EnsureSignedBy};
+use sp_core::H256;
+use sp_runtime::{traits::IdentityLookup, Permill};
+
+use orml_traits::parameter_type_with_key;
+
+// Types:
+pub type AccountId = u32;
+pub type BlockNumber = u64;
+pub type Hash = H256;
+pub type Moment = u64;
+pub type Balance = u128;
+pub type Amount = i128;
+pub type CurrencyId = u32;
+type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type Block = frame_system::mocking::MockBlock<Test>;
+
+// Constants:
+pub const MILLICENTS: Balance = 1_000_000_000;
+pub const CENTS: Balance = 1_000 * MILLICENTS;
+pub const DOLLARS: Balance = 100 * CENTS;
+pub const MILLISECS_PER_BLOCK: u64 = 6000;
+pub const MINUTES: BlockNumber = 60_000 / (MILLISECS_PER_BLOCK as BlockNumber);
+pub const HOURS: BlockNumber = MINUTES * 60;
+pub const DAYS: BlockNumber = HOURS * 24;
+pub const PROTOCOL_TOKEN_ID: CurrencyId = 1;
+pub const PAYMENT_TOKEN_ID: CurrencyId = 2;
+
+// Accounts:
+pub const ALICE: AccountId = 1;
+pub const BOB: AccountId = 2;
+pub const DAVE: AccountId = 3;
+
+mod zero_migration {
+	pub use super::super::*;
+}
+
+parameter_types! {
+	pub const BlockHashCount: u32 = 250;
+}
+
+impl frame_system::Config for Test {
+	type Origin = Origin;
+	type Index = u64;
+	type BlockNumber = BlockNumber;
+	type Call = Call;
+	type Hash = H256;
+	type Hashing = ::sp_runtime::traits::BlakeTwo256;
+	type AccountId = AccountId;
+	type Lookup = IdentityLookup<Self::AccountId>;
+	type Header = sp_runtime::testing::Header;
+	type Event = Event;
+	type BlockHashCount = BlockHashCount;
+	type BlockWeights = ();
+	type BlockLength = ();
+	type Version = ();
+	type PalletInfo = PalletInfo;
+	type AccountData = pallet_balances::AccountData<Balance>;
+	type OnNewAccount = ();
+	type OnKilledAccount = ();
+	type DbWeight = ();
+	type BaseCallFilter = Everything;
+	type SystemWeightInfo = ();
+	type SS58Prefix = ();
+	type OnSetCode = ();
+}
+
+parameter_type_with_key! {
+	pub ExistentialDeposits: |_currency_id: CurrencyId| -> Balance {
+		Default::default()
+	};
+}
+
+impl orml_tokens::Config for Test {
+	type Event = Event;
+	type Balance = Balance;
+	type Amount = Amount;
+	type CurrencyId = CurrencyId;
+	type WeightInfo = ();
+	type ExistentialDeposits = ExistentialDeposits;
+	type OnDust = ();
+	type MaxLocks = ();
+	type DustRemovalWhitelist = Nothing;
+}
+
+parameter_types! {
+	pub const ExistentialDeposit: Balance = 1;
+}
+
+impl pallet_balances::Config for Test {
+	type Balance = Balance;
+	type DustRemoval = ();
+	type Event = Event;
+	type ExistentialDeposit = ExistentialDeposit;
+	type AccountStore = frame_system::Pallet<Test>;
+	type MaxLocks = ();
+	type MaxReserves = ();
+	type ReserveIdentifier = [u8; 8];
+	type WeightInfo = ();
+}
+
+parameter_types! {
+	pub const BasicDeposit: u64 = 10;
+	pub const FieldDeposit: u64 = 10;
+	pub const SubAccountDeposit: u64 = 10;
+	pub const MaxSubAccounts: u32 = 2;
+	pub const MaxAdditionalFields: u32 = 2;
+	pub const MaxRegistrars: u32 = 20;
+}
+
+// ord_parameter_types! {
+// 	pub const One: u64 = 1;
+// 	pub const Two: u64 = 2;
+// }
+// type EnsureOneOrRoot = EnsureOneOf<u64, EnsureRoot<u64>, EnsureSignedBy<One, u64>>;
+// type EnsureTwoOrRoot = EnsureOneOf<u64, EnsureRoot<u64>, EnsureSignedBy<Two, u64>>;
+impl pallet_identity::Config for Test {
+	type Event = Event;
+	type Currency = Balances;
+	type Slashed = ();
+	type BasicDeposit = BasicDeposit;
+	type FieldDeposit = FieldDeposit;
+	type SubAccountDeposit = SubAccountDeposit;
+	type MaxSubAccounts = MaxSubAccounts;
+	type MaxAdditionalFields = MaxAdditionalFields;
+	type MaxRegistrars = MaxRegistrars;
+	type RegistrarOrigin = frame_system::EnsureRoot<Self::AccountId>;
+	type ForceOrigin = frame_system::EnsureRoot<Self::AccountId>;
+	type WeightInfo = ();
+}
+
+pub type AdaptedBasicCurrency = orml_currencies::BasicCurrencyAdapter<Test, Balances, Amount, BlockNumber>;
+
+impl orml_currencies::Config for Test {
+	type Event = Event;
+	type MultiCurrency = Tokens;
+	type NativeCurrency = AdaptedBasicCurrency;
+	type GetNativeCurrencyId = ();
+	type WeightInfo = ();
+}
+
+frame_support::parameter_types! {
+	pub const ProtocolTokenId: u32 = PROTOCOL_TOKEN_ID;
+	pub const PaymentTokenId: CurrencyId = PAYMENT_TOKEN_ID;
+}
+
+impl Config for Test {
+	type Event = Event;
+	type PaymentTokenId = PaymentTokenId;
+	type ProtocolTokenId = ProtocolTokenId;
+}
+
+construct_runtime!(
+	pub enum Test where
+		Block = Block,
+		NodeBlock = Block,
+		UncheckedExtrinsic = UncheckedExtrinsic,
+	{
+		System: frame_system::{Pallet, Call, Storage, Config, Event<T>},
+		Balances: pallet_balances::{Pallet, Call, Storage, Event<T>},
+		Identity: pallet_identity::{Pallet, Call, Storage, Event<T>},
+		Currencies: orml_currencies::{Pallet, Call, Event<T>},
+		Tokens: orml_tokens::{Pallet, Storage, Event<T>, Config<T>},
+
+		Migration: zero_migration,
+	}
+);
+
+pub fn new_test_ext() -> sp_io::TestExternalities {
+	let mut t = frame_system::GenesisConfig::default().build_storage::<Test>().unwrap();
+	pallet_balances::GenesisConfig::<Test> { 
+		balances: vec![
+			// (ALICE, 100 * DOLLARS),
+			// (BOB, 50 * DOLLARS),
+		],
+	}
+	.assimilate_storage(&mut t)
+	.unwrap();
+	t.into()
+}

--- a/migration/migration/src/mock.rs
+++ b/migration/migration/src/mock.rs
@@ -2,12 +2,11 @@
 
 pub use super::*;
 use frame_support::{
-	construct_runtime, parameter_types, ord_parameter_types,
-	traits::{Everything, GenesisBuild, Nothing},
+	construct_runtime, parameter_types,
+	traits::{Everything, Nothing},
 };
-use frame_system::{EnsureOneOf, EnsureRoot, EnsureSignedBy};
 use sp_core::H256;
-use sp_runtime::{traits::IdentityLookup, Permill};
+use sp_runtime::{traits::IdentityLookup};
 
 use orml_traits::parameter_type_with_key;
 
@@ -115,12 +114,6 @@ parameter_types! {
 	pub const MaxRegistrars: u32 = 20;
 }
 
-// ord_parameter_types! {
-// 	pub const One: u64 = 1;
-// 	pub const Two: u64 = 2;
-// }
-// type EnsureOneOrRoot = EnsureOneOf<u64, EnsureRoot<u64>, EnsureSignedBy<One, u64>>;
-// type EnsureTwoOrRoot = EnsureOneOf<u64, EnsureRoot<u64>, EnsureSignedBy<Two, u64>>;
 impl pallet_identity::Config for Test {
 	type Event = Event;
 	type Currency = Balances;
@@ -133,16 +126,6 @@ impl pallet_identity::Config for Test {
 	type MaxRegistrars = MaxRegistrars;
 	type RegistrarOrigin = frame_system::EnsureRoot<Self::AccountId>;
 	type ForceOrigin = frame_system::EnsureRoot<Self::AccountId>;
-	type WeightInfo = ();
-}
-
-pub type AdaptedBasicCurrency = orml_currencies::BasicCurrencyAdapter<Test, Balances, Amount, BlockNumber>;
-
-impl orml_currencies::Config for Test {
-	type Event = Event;
-	type MultiCurrency = Tokens;
-	type NativeCurrency = AdaptedBasicCurrency;
-	type GetNativeCurrencyId = ();
 	type WeightInfo = ();
 }
 
@@ -166,21 +149,14 @@ construct_runtime!(
 		System: frame_system::{Pallet, Call, Storage, Config, Event<T>},
 		Balances: pallet_balances::{Pallet, Call, Storage, Event<T>},
 		Identity: pallet_identity::{Pallet, Call, Storage, Event<T>},
-		Currencies: orml_currencies::{Pallet, Call, Event<T>},
 		Tokens: orml_tokens::{Pallet, Storage, Event<T>, Config<T>},
-
 		Migration: zero_migration,
 	}
 );
 
 pub fn new_test_ext() -> sp_io::TestExternalities {
 	let mut t = frame_system::GenesisConfig::default().build_storage::<Test>().unwrap();
-	pallet_balances::GenesisConfig::<Test> { 
-		balances: vec![
-			// (ALICE, 100 * DOLLARS),
-			// (BOB, 50 * DOLLARS),
-		],
-	}
+	pallet_balances::GenesisConfig::<Test> { balances: vec![] }
 	.assimilate_storage(&mut t)
 	.unwrap();
 	t.into()

--- a/migration/migration/src/tests.rs
+++ b/migration/migration/src/tests.rs
@@ -1,33 +1,27 @@
 #![cfg(test)]
 
 use super::*;
-use codec::Encode;
-// use frame_support::traits::Hooks;
-use frame_support::{assert_noop, assert_ok};
-use frame_system::{EventRecord, Phase, RawOrigin};
-use mock::{Event, Moment, *};
-// use sp_core::H256;
+use frame_support::assert_ok;
+use mock::*;
 
 
 #[test]
 fn migration_tokens_airdrop() {
 	new_test_ext().execute_with(|| {
-
+		// Set initial Balances
 		Balances::make_free_balance_be(&ALICE, 100);
-		// Balances::make_free_balance_be(&BOB, 50);
-		// Balances::make_free_balance_be(&DAVE, 0);
-
+		Balances::make_free_balance_be(&BOB, 50);
+		Balances::make_free_balance_be(&DAVE, 0);
+		// Proceed with airdrop
 		assert_ok!(Migration::tokens_airdrop(Origin::root()));
-
-		// for (account_id, account_data) in frame_system::Account::<Test>::iter() {
-		// 	assert_eq!(account_id, 2);
-		// }
-
-		assert_eq!(
-			orml_tokens::Accounts::<Test>::get(ALICE, PROTOCOL_TOKEN_ID).free,
-			100
-		);
-		
-		
+		// Check if tokens were sent
+		assert_eq!(orml_tokens::Accounts::<Test>::get(ALICE, PROTOCOL_TOKEN_ID).free, 100);
+		assert_eq!(orml_tokens::Accounts::<Test>::get(ALICE, PAYMENT_TOKEN_ID).free, 100);
+		assert_eq!(orml_tokens::Accounts::<Test>::get(BOB, PROTOCOL_TOKEN_ID).free, 50);
+		assert_eq!(orml_tokens::Accounts::<Test>::get(BOB, PAYMENT_TOKEN_ID).free, 50);
+		assert_eq!(orml_tokens::Accounts::<Test>::get(DAVE, PROTOCOL_TOKEN_ID).free, 0);
+		assert_eq!(orml_tokens::Accounts::<Test>::get(DAVE, PAYMENT_TOKEN_ID).free, 0);
+		// Event
+		// System::assert_has_event(mock::Event::Migration(crate::Event::TokensAirDropped(1)));
 	});
 }

--- a/migration/migration/src/tests.rs
+++ b/migration/migration/src/tests.rs
@@ -1,0 +1,33 @@
+#![cfg(test)]
+
+use super::*;
+use codec::Encode;
+// use frame_support::traits::Hooks;
+use frame_support::{assert_noop, assert_ok};
+use frame_system::{EventRecord, Phase, RawOrigin};
+use mock::{Event, Moment, *};
+// use sp_core::H256;
+
+
+#[test]
+fn migration_tokens_airdrop() {
+	new_test_ext().execute_with(|| {
+
+		Balances::make_free_balance_be(&ALICE, 100);
+		// Balances::make_free_balance_be(&BOB, 50);
+		// Balances::make_free_balance_be(&DAVE, 0);
+
+		assert_ok!(Migration::tokens_airdrop(Origin::root()));
+
+		// for (account_id, account_data) in frame_system::Account::<Test>::iter() {
+		// 	assert_eq!(account_id, 2);
+		// }
+
+		assert_eq!(
+			orml_tokens::Accounts::<Test>::get(ALICE, PROTOCOL_TOKEN_ID).free,
+			100
+		);
+		
+		
+	});
+}

--- a/migration/migration/src/tests.rs
+++ b/migration/migration/src/tests.rs
@@ -1,7 +1,8 @@
 #![cfg(test)]
 
 use super::*;
-use frame_support::assert_ok;
+use frame_support::{assert_ok, assert_noop};
+use sp_runtime::traits::BadOrigin;
 use mock::*;
 
 
@@ -12,6 +13,7 @@ fn migration_tokens_airdrop() {
 		Balances::make_free_balance_be(&ALICE, 100);
 		Balances::make_free_balance_be(&BOB, 50);
 		Balances::make_free_balance_be(&DAVE, 0);
+		Balances::make_free_balance_be(&TREASURY, 999);
 		// Proceed with airdrop
 		assert_ok!(Migration::tokens_airdrop(Origin::root()));
 		// Check if tokens were sent
@@ -21,7 +23,11 @@ fn migration_tokens_airdrop() {
 		assert_eq!(orml_tokens::Accounts::<Test>::get(BOB, PAYMENT_TOKEN_ID).free, 50);
 		assert_eq!(orml_tokens::Accounts::<Test>::get(DAVE, PROTOCOL_TOKEN_ID).free, 0);
 		assert_eq!(orml_tokens::Accounts::<Test>::get(DAVE, PAYMENT_TOKEN_ID).free, 0);
+		assert_eq!(orml_tokens::Accounts::<Test>::get(TREASURY, PROTOCOL_TOKEN_ID).free, 0);
+		assert_eq!(orml_tokens::Accounts::<Test>::get(TREASURY, PAYMENT_TOKEN_ID).free, 0);
+		// Check origin
+		assert_noop!(Migration::tokens_airdrop(Origin::signed(ALICE)), BadOrigin);
 		// TODO: Event test
-		// System::assert_has_event(mock::Event::Migration(crate::Event::TokensAirDropped(1)));
+		// System::assert_has_event(mock::Event::Migration(crate::Event::TokensAirDropped(3)));
 	});
 }

--- a/migration/migration/src/tests.rs
+++ b/migration/migration/src/tests.rs
@@ -21,7 +21,7 @@ fn migration_tokens_airdrop() {
 		assert_eq!(orml_tokens::Accounts::<Test>::get(BOB, PAYMENT_TOKEN_ID).free, 50);
 		assert_eq!(orml_tokens::Accounts::<Test>::get(DAVE, PROTOCOL_TOKEN_ID).free, 0);
 		assert_eq!(orml_tokens::Accounts::<Test>::get(DAVE, PAYMENT_TOKEN_ID).free, 0);
-		// Event
+		// TODO: Event test
 		// System::assert_has_event(mock::Event::Migration(crate::Event::TokensAirDropped(1)));
 	});
 }


### PR DESCRIPTION
Issue: [https://github.com/gamedaoco/gamedao-protocol/issues/39](https://github.com/gamedaoco/gamedao-protocol/issues/39)

- Add Extrinsic `tokens_airdrop` (root origin) to the `zero-migration` pallet
- Add tests

Extrinsic was used instead of `on_runtime_upgrade` because root origin is needed to interact with `orml-tokens.`