### PR TITLE
feat(cli): autoselect alphaville

### DIFF
--- a/bin/zero/cli/Cargo.toml
+++ b/bin/zero/cli/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "zero-cli"
-version = "3.0.0-dev"
+version = "2.0.55"
 authors = ["ZERO <play@zero.io>"]
-description = "Generic Substrate node implementation in Rust."
+description = "a substrate node for video games and beyond"
 build = "build.rs"
 edition = "2021"
 license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
@@ -27,7 +27,6 @@ is-it-maintained-open-issues = { repository = "playzero/zero-network" }
 [[bin]]
 name = "subzero"
 path = "bin/main.rs"
-required-features = ["cli"]
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/bin/zero/cli/Cargo.toml
+++ b/bin/zero/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zero-cli"
-version = "2.0.55"
+version = "3.0.55"
 authors = ["ZERO <play@zero.io>"]
 description = "a substrate node for video games and beyond"
 build = "build.rs"

--- a/bin/zero/cli/src/command.rs
+++ b/bin/zero/cli/src/command.rs
@@ -24,7 +24,7 @@ use sc_service::PartialComponents;
 
 impl SubstrateCli for Cli {
 	fn impl_name() -> String {
-		"ZERO Node".into()
+		"S U B Z E R O".into()
 	}
 
 	fn impl_version() -> String {
@@ -49,14 +49,15 @@ impl SubstrateCli for Cli {
 
 	fn load_spec(&self, id: &str) -> std::result::Result<Box<dyn sc_service::ChainSpec>, String> {
 		let spec = match id {
-			"" =>
-				return Err(
-					"Please specify which chain you want to run, e.g. --dev or --chain=local"
-						.into(),
-				),
+			// "" =>
+			// 	return Err(
+			// 		"Please specify which chain you want to run, e.g. --dev or --chain=local"
+			// 			.into(),
+			// 	),
 			"dev" => Box::new(chain_spec::development_config()),
 			"local" => Box::new(chain_spec::local_testnet_config()),
-			"subzero" | "alphaville" => Box::new(chain_spec::subzero_config()?),
+			// default to alphaville when running without param to be compatible to old behaviour
+			"" | "subzero" | "alphaville" => Box::new(chain_spec::subzero_config()?),
 			"staging" => Box::new(chain_spec::staging_testnet_config()),
 			path =>
 				Box::new(chain_spec::ChainSpec::from_json_file(std::path::PathBuf::from(path))?),

--- a/bin/zero/runtime/src/lib.rs
+++ b/bin/zero/runtime/src/lib.rs
@@ -124,7 +124,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to 0. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 54,
+	spec_version: 55,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,
@@ -1494,6 +1494,8 @@ construct_runtime!(
 		Sense: gamedao_sense,
 		Control: gamedao_control,
 		Signal: gamedao_signal,
+
+		// GameDAOCouncil: pallet_collective::<Instance3>,
 		GameDAOTreasury: gamedao_treasury,
 
 		// Zero pallets:

--- a/bin/zero/runtime/src/lib.rs
+++ b/bin/zero/runtime/src/lib.rs
@@ -1495,7 +1495,6 @@ construct_runtime!(
 		Control: gamedao_control,
 		Signal: gamedao_signal,
 
-		// GameDAOCouncil: pallet_collective::<Instance3>,
 		GameDAOTreasury: gamedao_treasury,
 
 		// Zero pallets:


### PR DESCRIPTION
- node operators launched the chain in the past without explicitly selecting a spec.
- this pr reintroduces this behaviour, so running the chain without selecting, implicitly selects alphaville when there is no chain spec parameter.
