### PR TITLE
2075/parachain meta

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2275,7 +2275,7 @@ dependencies = [
  "frame-support-test-pallet",
  "frame-system",
  "parity-scale-codec",
- "pretty_assertions 1.2.0",
+ "pretty_assertions 1.2.1",
  "rustversion",
  "scale-info",
  "serde",
@@ -5956,122 +5956,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parachain-subzero-node"
-version = "0.1.0"
-dependencies = [
- "cumulus-client-cli",
- "cumulus-client-collator",
- "cumulus-client-consensus-aura",
- "cumulus-client-consensus-common",
- "cumulus-client-network",
- "cumulus-client-service",
- "cumulus-primitives-core",
- "cumulus-primitives-parachain-inherent",
- "derive_more",
- "frame-benchmarking",
- "frame-benchmarking-cli",
- "hex-literal",
- "jsonrpc-core",
- "log",
- "pallet-transaction-payment-rpc",
- "parachain-subzero-runtime",
- "parity-scale-codec",
- "polkadot-cli",
- "polkadot-parachain",
- "polkadot-primitives",
- "polkadot-service",
- "sc-basic-authorship",
- "sc-chain-spec",
- "sc-cli",
- "sc-client-api",
- "sc-consensus",
- "sc-executor",
- "sc-keystore",
- "sc-network",
- "sc-rpc",
- "sc-rpc-api",
- "sc-service",
- "sc-telemetry",
- "sc-tracing",
- "sc-transaction-pool",
- "sc-transaction-pool-api",
- "serde",
- "sp-api",
- "sp-block-builder",
- "sp-blockchain",
- "sp-consensus",
- "sp-consensus-aura",
- "sp-core",
- "sp-inherents",
- "sp-keystore",
- "sp-offchain",
- "sp-runtime",
- "sp-session",
- "sp-timestamp",
- "sp-transaction-pool",
- "structopt",
- "substrate-build-script-utils",
- "substrate-frame-rpc-system",
- "substrate-prometheus-endpoint",
-]
-
-[[package]]
-name = "parachain-subzero-runtime"
-version = "0.1.0"
-dependencies = [
- "cumulus-pallet-aura-ext",
- "cumulus-pallet-dmp-queue",
- "cumulus-pallet-parachain-system",
- "cumulus-pallet-session-benchmarking",
- "cumulus-pallet-xcm",
- "cumulus-pallet-xcmp-queue",
- "cumulus-primitives-core",
- "cumulus-primitives-timestamp",
- "cumulus-primitives-utility",
- "frame-benchmarking",
- "frame-executive",
- "frame-support",
- "frame-system",
- "frame-system-benchmarking",
- "frame-system-rpc-runtime-api",
- "hex-literal",
- "log",
- "pallet-aura",
- "pallet-authorship",
- "pallet-balances",
- "pallet-collator-selection",
- "pallet-session",
- "pallet-sudo",
- "pallet-timestamp",
- "pallet-transaction-payment",
- "pallet-transaction-payment-rpc-runtime-api",
- "pallet-xcm",
- "parachain-info",
- "parity-scale-codec",
- "polkadot-parachain",
- "polkadot-runtime-common",
- "scale-info",
- "serde",
- "smallvec",
- "sp-api",
- "sp-block-builder",
- "sp-consensus-aura",
- "sp-core",
- "sp-inherents",
- "sp-io",
- "sp-offchain",
- "sp-runtime",
- "sp-session",
- "sp-std",
- "sp-transaction-pool",
- "sp-version",
- "substrate-wasm-builder",
- "xcm",
- "xcm-builder",
- "xcm-executor",
-]
-
-[[package]]
 name = "parity-db"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7559,9 +7443,9 @@ dependencies = [
 
 [[package]]
 name = "pretty_assertions"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c038cb5319b9c704bf9c227c261d275bfec0ad438118a2787ce47944fb228b"
+checksum = "c89f989ac94207d048d92db058e4f6ec7342b0971fc58d1271ca148b799b3563"
 dependencies = [
  "ansi_term 0.12.1",
  "ctor",
@@ -10627,6 +10511,122 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
+name = "subzero-parachain-node"
+version = "0.1.0"
+dependencies = [
+ "cumulus-client-cli",
+ "cumulus-client-collator",
+ "cumulus-client-consensus-aura",
+ "cumulus-client-consensus-common",
+ "cumulus-client-network",
+ "cumulus-client-service",
+ "cumulus-primitives-core",
+ "cumulus-primitives-parachain-inherent",
+ "derive_more",
+ "frame-benchmarking",
+ "frame-benchmarking-cli",
+ "hex-literal",
+ "jsonrpc-core",
+ "log",
+ "pallet-transaction-payment-rpc",
+ "parity-scale-codec",
+ "polkadot-cli",
+ "polkadot-parachain",
+ "polkadot-primitives",
+ "polkadot-service",
+ "sc-basic-authorship",
+ "sc-chain-spec",
+ "sc-cli",
+ "sc-client-api",
+ "sc-consensus",
+ "sc-executor",
+ "sc-keystore",
+ "sc-network",
+ "sc-rpc",
+ "sc-rpc-api",
+ "sc-service",
+ "sc-telemetry",
+ "sc-tracing",
+ "sc-transaction-pool",
+ "sc-transaction-pool-api",
+ "serde",
+ "sp-api",
+ "sp-block-builder",
+ "sp-blockchain",
+ "sp-consensus",
+ "sp-consensus-aura",
+ "sp-core",
+ "sp-inherents",
+ "sp-keystore",
+ "sp-offchain",
+ "sp-runtime",
+ "sp-session",
+ "sp-timestamp",
+ "sp-transaction-pool",
+ "structopt",
+ "substrate-build-script-utils",
+ "substrate-frame-rpc-system",
+ "substrate-prometheus-endpoint",
+ "subzero-parachain-runtime",
+]
+
+[[package]]
+name = "subzero-parachain-runtime"
+version = "0.1.0"
+dependencies = [
+ "cumulus-pallet-aura-ext",
+ "cumulus-pallet-dmp-queue",
+ "cumulus-pallet-parachain-system",
+ "cumulus-pallet-session-benchmarking",
+ "cumulus-pallet-xcm",
+ "cumulus-pallet-xcmp-queue",
+ "cumulus-primitives-core",
+ "cumulus-primitives-timestamp",
+ "cumulus-primitives-utility",
+ "frame-benchmarking",
+ "frame-executive",
+ "frame-support",
+ "frame-system",
+ "frame-system-benchmarking",
+ "frame-system-rpc-runtime-api",
+ "hex-literal",
+ "log",
+ "pallet-aura",
+ "pallet-authorship",
+ "pallet-balances",
+ "pallet-collator-selection",
+ "pallet-session",
+ "pallet-sudo",
+ "pallet-timestamp",
+ "pallet-transaction-payment",
+ "pallet-transaction-payment-rpc-runtime-api",
+ "pallet-xcm",
+ "parachain-info",
+ "parity-scale-codec",
+ "polkadot-parachain",
+ "polkadot-runtime-common",
+ "scale-info",
+ "serde",
+ "smallvec",
+ "sp-api",
+ "sp-block-builder",
+ "sp-consensus-aura",
+ "sp-core",
+ "sp-inherents",
+ "sp-io",
+ "sp-offchain",
+ "sp-runtime",
+ "sp-session",
+ "sp-std",
+ "sp-transaction-pool",
+ "sp-version",
+ "substrate-wasm-builder",
+ "xcm",
+ "xcm-builder",
+ "xcm-executor",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11080,13 +11080,14 @@ dependencies = [
 
 [[package]]
 name = "trybuild"
-version = "1.0.56"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d60539445867cdd9680b2bfe2d0428f1814b7d5c9652f09d8d3eae9d19308db"
+checksum = "764b9e244b482a9b81bde596aa37aa6f1347bf8007adab25e59f901b32b4e0a0"
 dependencies = [
  "glob",
  "once_cell",
  "serde",
+ "serde_derive",
  "serde_json",
  "termcolor",
  "toml",
@@ -11405,6 +11406,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d958d035c4438e28c70e4321a2911302f10135ce78a9c7834c0cab4123d06a2"
 
 [[package]]
+name = "wasm-encoder"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31f0c17267a5ffd6ae3d897589460e21db1673c84fb7016b909c9691369a75ea"
+dependencies = [
+ "leb128",
+]
+
+[[package]]
 name = "wasm-gc-api"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11621,20 +11631,21 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "40.0.0"
+version = "42.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bb4f48a8b083dbc50e291e430afb8f524092bb00428957bcc63f49f856c64ac"
+checksum = "badcb03f976f983ff0daf294da9697be659442f61e6b0942bb37a2b6cbfe9dd4"
 dependencies = [
  "leb128",
  "memchr",
  "unicode-width",
+ "wasm-encoder",
 ]
 
 [[package]]
 name = "wat"
-version = "1.0.42"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0401b6395ce0db91629a75b29597ccb66ea29950af9fc859f1bb3a736609c76e"
+checksum = "b92f20b742ac527066c8414bc0637352661b68cab07ef42586cefaba71c965cf"
 dependencies = [
  "wast",
 ]
@@ -11849,7 +11860,7 @@ dependencies = [
 
 [[package]]
 name = "zero-cli"
-version = "3.0.0-dev"
+version = "3.0.55"
 dependencies = [
  "assert_cmd",
  "async-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,47 +5,29 @@ resolver = "2"
 
 members = [
 
-	"bin/zero/runtime",
 	"bin/zero/cli",
-
-	# "bin/zero-dev/runtime",
-	# "bin/zero-dev/node",
-
-	"bin/zero-parachain/runtime",
-	"bin/zero-parachain/node",
-
-	"orml/currencies",
-	"orml/traits",
-	"orml/tokens",
-	"gamedao-protocol/flow",
-	"gamedao-protocol/control",
-	"gamedao-protocol/signal",
-	"gamedao-protocol/sense",
-	"gamedao-protocol/traits",
-	"primitives",
-
-	# "bin/zero/cli",
-
+	"bin/zero/runtime",
 	# "bin/zero/bench",
 	# "bin/zero/test-runner-example",
 	# "bin/zero/executor",
 	# "bin/zero/primitives",
 	# "bin/zero/rpc",
-	# "bin/zero/runtime",
 	# "bin/zero/testing",
+
+	# "bin/zero-dev/node",
+	# "bin/zero-dev/runtime",
+
+	"bin/zero-parachain/node",
+	"bin/zero-parachain/runtime",
+
+	# "ext/orml/*",
+	# "ext/gamedao-protocol/*",
+	# "ext/zero/*",
+	# "primitives",
 
 	# "bin/node-template/node",
 	# "bin/node-template/pallets/template",
 	# "bin/node-template/runtime",
-
-	# "bin/node/bench",
-	# "bin/node/cli",
-	# "bin/node/test-runner-example",
-	# "bin/node/executor",
-	# "bin/node/primitives",
-	# "bin/node/rpc",
-	# "bin/node/runtime",
-	# "bin/node/testing",
 
 	# "bin/utils/chain-spec-builder",
 	# "bin/utils/subkey",

--- a/bin/zero-dev/node/Cargo.toml
+++ b/bin/zero-dev/node/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "node-template"
+name = "subzero-dev-node"
 version = "3.0.0"
 description = "A fresh FRAME-based Substrate node, ready for hacking."
 authors = ["Substrate DevHub <https://github.com/substrate-developer-hub>"]
@@ -13,8 +13,8 @@ build = "build.rs"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
-[[bin]]
-name = "node-template"
+# [[bin]]
+# name = "subzero-dev"
 
 [dependencies]
 structopt = "0.3.25"
@@ -52,13 +52,13 @@ pallet-transaction-payment-rpc = { git = "https://github.com/paritytech/substrat
 frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.13" }
 frame-benchmarking-cli = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.13" }
 
-node-template-runtime = { version = "3.0.0", path = "../runtime" }
+subzero-dev-runtime = { version = "3.0.0", path = "../runtime" }
 
 [build-dependencies]
 substrate-build-script-utils = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.13" }
 
 [features]
-default = []
+dev = []
 runtime-benchmarks = [
-	"node-template-runtime/runtime-benchmarks",
+	"subzero-dev-runtime/runtime-benchmarks",
 ]

--- a/bin/zero-dev/node/src/chain_spec.rs
+++ b/bin/zero-dev/node/src/chain_spec.rs
@@ -1,4 +1,4 @@
-use node_template_runtime::{
+use subzero_dev_runtime::{
 	AccountId, AuraConfig, BalancesConfig, GenesisConfig, GrandpaConfig, Signature, SudoConfig,
 	SystemConfig, WASM_BINARY,
 };

--- a/bin/zero-dev/node/src/command.rs
+++ b/bin/zero-dev/node/src/command.rs
@@ -3,13 +3,13 @@ use crate::{
 	cli::{Cli, Subcommand},
 	service,
 };
-use node_template_runtime::Block;
+use subzero_dev_runtime::Block;
 use sc_cli::{ChainSpec, RuntimeVersion, SubstrateCli};
 use sc_service::PartialComponents;
 
 impl SubstrateCli for Cli {
 	fn impl_name() -> String {
-		"Substrate Node".into()
+		"subzero dev".into()
 	}
 
 	fn impl_version() -> String {

--- a/bin/zero-dev/node/src/rpc.rs
+++ b/bin/zero-dev/node/src/rpc.rs
@@ -7,7 +7,7 @@
 
 use std::sync::Arc;
 
-use node_template_runtime::{opaque::Block, AccountId, Balance, Index};
+use subzero_dev_runtime::{opaque::Block, AccountId, Balance, Index};
 pub use sc_rpc_api::DenyUnsafe;
 use sc_transaction_pool_api::TransactionPool;
 use sp_api::ProvideRuntimeApi;

--- a/bin/zero-dev/node/src/service.rs
+++ b/bin/zero-dev/node/src/service.rs
@@ -1,6 +1,6 @@
 //! Service and ServiceFactory implementation. Specialized wrapper over substrate service.
 
-use node_template_runtime::{self, opaque::Block, RuntimeApi};
+use subzero_dev_runtime::{self, opaque::Block, RuntimeApi};
 use sc_client_api::ExecutorProvider;
 use sc_consensus_aura::{ImportQueueParams, SlotProportion, StartAuraParams};
 pub use sc_executor::NativeElseWasmExecutor;

--- a/bin/zero-dev/runtime/Cargo.toml
+++ b/bin/zero-dev/runtime/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "node-template-runtime"
+name = "subzero-dev-runtime"
 version = "3.0.0"
 description = 'A fresh FRAME-based Substrate runtime, ready for hacking.'
 authors = ["Substrate DevHub <https://github.com/substrate-developer-hub>"]
@@ -17,8 +17,10 @@ codec = { package = "parity-scale-codec", version = "2.0.0", default-features = 
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
 
 pallet-aura = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.13" }
-pallet-balances = { path = "../../../frame/balances", default-features = false }
-pallet-identity = { path = "../../../frame/identity", default-features = false }
+# pallet-balances = { path = "../../../frame/balances", default-features = false }
+# pallet-identity = { path = "../../../frame/identity", default-features = false }
+pallet-balances = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.13" }
+pallet-identity = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.13" }
 pallet-bounties = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.13" }
 pallet-treasury = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.13" }
 frame-support = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.13" }
@@ -67,8 +69,8 @@ hex-literal = { version = "0.3.4", optional = true }
 substrate-wasm-builder = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.13" }
 
 [features]
-default = ["std"]
-std = [
+# default = ["std"]
+dev = [
 	"codec/std",
 	"scale-info/std",
 	"frame-executive/std",

--- a/bin/zero-dev/scripts/docker_run.sh
+++ b/bin/zero-dev/scripts/docker_run.sh
@@ -2,7 +2,7 @@
 # This script is meant to be run on Unix/Linux based systems
 set -e
 
-echo "*** Start Substrate node template ***"
+echo "*** start subzero develpoment node ***"
 
 cd $(dirname ${BASH_SOURCE[0]})/..
 

--- a/bin/zero-parachain/node/Cargo.toml
+++ b/bin/zero-parachain/node/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
-name = "parachain-subzero-node"
+name = "subzero-parachain-node"
 version = "0.1.0"
-authors = ["Anonymous"]
+authors = ["Anonymouse"]
 description = "A new Cumulus FRAME-based Substrate Node, ready for hacking together a parachain."
 license = "Unlicense"
 homepage = "https://substrate.io"
@@ -32,7 +32,7 @@ hex-literal = "0.3.1"
 jsonrpc-core = "18.0.0"
 
 # Local Dependencies
-parachain-subzero-runtime = { path = "../runtime" }
+subzero-parachain-runtime = { path = "../runtime" }
 
 # Substrate Dependencies
 frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.13" }
@@ -94,6 +94,6 @@ polkadot-service = { git = "https://github.com/paritytech/polkadot", branch = "r
 
 [features]
 runtime-benchmarks = [
-	"parachain-subzero-runtime/runtime-benchmarks"
+	"subzero-parachain-runtime/runtime-benchmarks"
 ]
 parachain = []

--- a/bin/zero-parachain/node/src/chain_spec.rs
+++ b/bin/zero-parachain/node/src/chain_spec.rs
@@ -1,5 +1,5 @@
 use cumulus_primitives_core::ParaId;
-use parachain_subzero_runtime::{AccountId, AuraId, Signature, EXISTENTIAL_DEPOSIT};
+use subzero_parachain_runtime::{AccountId, AuraId, Signature, EXISTENTIAL_DEPOSIT};
 use sc_chain_spec::{ChainSpecExtension, ChainSpecGroup};
 use sc_service::ChainType;
 use serde::{Deserialize, Serialize};
@@ -8,7 +8,7 @@ use sp_runtime::traits::{IdentifyAccount, Verify};
 
 /// Specialized `ChainSpec` for the normal parachain runtime.
 pub type ChainSpec =
-	sc_service::GenericChainSpec<parachain_subzero_runtime::GenesisConfig, Extensions>;
+	sc_service::GenericChainSpec<subzero_parachain_runtime::GenesisConfig, Extensions>;
 
 /// Helper function to generate a crypto pair from seed
 pub fn get_public_from_seed<TPublic: Public>(seed: &str) -> <TPublic::Pair as Pair>::Public {
@@ -54,8 +54,8 @@ where
 /// Generate the session keys from individual elements.
 ///
 /// The input must be a tuple of individual keys (a single arg for now since we have just one key).
-pub fn template_session_keys(keys: AuraId) -> parachain_subzero_runtime::SessionKeys {
-	parachain_subzero_runtime::SessionKeys { aura: keys }
+pub fn template_session_keys(keys: AuraId) -> subzero_parachain_runtime::SessionKeys {
+	subzero_parachain_runtime::SessionKeys { aura: keys }
 }
 
 pub fn development_config() -> ChainSpec {
@@ -175,23 +175,23 @@ fn testnet_genesis(
 	invulnerables: Vec<(AccountId, AuraId)>,
 	endowed_accounts: Vec<AccountId>,
 	id: ParaId,
-) -> parachain_subzero_runtime::GenesisConfig {
-	parachain_subzero_runtime::GenesisConfig {
-		system: parachain_subzero_runtime::SystemConfig {
-			code: parachain_subzero_runtime::WASM_BINARY
+) -> subzero_parachain_runtime::GenesisConfig {
+	subzero_parachain_runtime::GenesisConfig {
+		system: subzero_parachain_runtime::SystemConfig {
+			code: subzero_parachain_runtime::WASM_BINARY
 				.expect("WASM binary was not build, please build it!")
 				.to_vec(),
 		},
-		balances: parachain_subzero_runtime::BalancesConfig {
+		balances: subzero_parachain_runtime::BalancesConfig {
 			balances: endowed_accounts.iter().cloned().map(|k| (k, 1 << 60)).collect(),
 		},
-		parachain_info: parachain_subzero_runtime::ParachainInfoConfig { parachain_id: id },
-		collator_selection: parachain_subzero_runtime::CollatorSelectionConfig {
+		parachain_info: subzero_parachain_runtime::ParachainInfoConfig { parachain_id: id },
+		collator_selection: subzero_parachain_runtime::CollatorSelectionConfig {
 			invulnerables: invulnerables.iter().cloned().map(|(acc, _)| acc).collect(),
 			candidacy_bond: EXISTENTIAL_DEPOSIT * 16,
 			..Default::default()
 		},
-		session: parachain_subzero_runtime::SessionConfig {
+		session: subzero_parachain_runtime::SessionConfig {
 			keys: invulnerables
 				.into_iter()
 				.map(|(acc, aura)| {

--- a/bin/zero-parachain/node/src/command.rs
+++ b/bin/zero-parachain/node/src/command.rs
@@ -7,7 +7,7 @@ use codec::Encode;
 use cumulus_client_service::genesis::generate_genesis_block;
 use cumulus_primitives_core::ParaId;
 use log::info;
-use parachain_subzero_runtime::{Block, RuntimeApi};
+use subzero_parachain_runtime::{Block, RuntimeApi};
 use polkadot_parachain::primitives::AccountIdConversion;
 use sc_cli::{
 	ChainSpec, CliConfiguration, DefaultConfigurationValues, ImportParams, KeystoreParams,
@@ -61,7 +61,7 @@ impl SubstrateCli for Cli {
 	}
 
 	fn native_runtime_version(_: &Box<dyn ChainSpec>) -> &'static RuntimeVersion {
-		&parachain_subzero_runtime::VERSION
+		&subzero_parachain_runtime::VERSION
 	}
 }
 

--- a/bin/zero-parachain/node/src/command.rs
+++ b/bin/zero-parachain/node/src/command.rs
@@ -29,7 +29,7 @@ fn load_spec(id: &str) -> std::result::Result<Box<dyn sc_service::ChainSpec>, St
 
 impl SubstrateCli for Cli {
 	fn impl_name() -> String {
-		"Parachain Collator Template".into()
+		"subzero parachain collator".into()
 	}
 
 	fn impl_version() -> String {
@@ -37,10 +37,10 @@ impl SubstrateCli for Cli {
 	}
 
 	fn description() -> String {
-		"Parachain Collator Template\n\nThe command-line arguments provided first will be \
+		"subzero parachain collator \n\nThe command-line arguments provided first will be \
 		passed to the parachain node, while the arguments provided after -- will be passed \
 		to the relay chain node.\n\n\
-		parachain-collator <parachain-args> -- <relay-chain-args>"
+		subzero-collator <parachain-args> -- <relay-chain-args>"
 			.into()
 	}
 
@@ -67,7 +67,7 @@ impl SubstrateCli for Cli {
 
 impl SubstrateCli for RelayChainCli {
 	fn impl_name() -> String {
-		"Parachain Collator Template".into()
+		"subzero parachain collator".into()
 	}
 
 	fn impl_version() -> String {

--- a/bin/zero-parachain/node/src/rpc.rs
+++ b/bin/zero-parachain/node/src/rpc.rs
@@ -7,7 +7,7 @@
 
 use std::sync::Arc;
 
-use parachain_subzero_runtime::{opaque::Block, AccountId, Balance, Index as Nonce};
+use subzero_parachain_runtime::{opaque::Block, AccountId, Balance, Index as Nonce};
 
 use sc_client_api::AuxStore;
 pub use sc_rpc::{DenyUnsafe, SubscriptionTaskExecutor};

--- a/bin/zero-parachain/node/src/service.rs
+++ b/bin/zero-parachain/node/src/service.rs
@@ -4,7 +4,7 @@
 use std::sync::Arc;
 
 // Local Runtime Types
-use parachain_subzero_runtime::{
+use subzero_parachain_runtime::{
 	opaque::Block, AccountId, Balance, Hash, Index as Nonce, RuntimeApi,
 };
 
@@ -38,11 +38,11 @@ impl sc_executor::NativeExecutionDispatch for RuntimeExecutor {
 	type ExtendHostFunctions = frame_benchmarking::benchmarking::HostFunctions;
 
 	fn dispatch(method: &str, data: &[u8]) -> Option<Vec<u8>> {
-		parachain_subzero_runtime::api::dispatch(method, data)
+		subzero_parachain_runtime::api::dispatch(method, data)
 	}
 
 	fn native_version() -> sc_executor::NativeVersion {
-		parachain_subzero_runtime::native_version()
+		subzero_parachain_runtime::native_version()
 	}
 }
 

--- a/bin/zero-parachain/runtime/Cargo.toml
+++ b/bin/zero-parachain/runtime/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
-name = "parachain-subzero-runtime"
+name = "subzero-parachain-runtime"
 version = "0.1.0"
-authors = ["Anonymous"]
+authors = ["Anonymouse"]
 description = "A new Cumulus FRAME-based Substrate Runtime, ready for hacking together a parachain."
 license = "Unlicense"
 homepage = "https://substrate.io"

--- a/bin/zero/cli/benches/block_production.rs
+++ b/bin/zero/cli/benches/block_production.rs
@@ -18,13 +18,13 @@
 
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion, Throughput};
 
-use node_cli::service::{create_extrinsic, FullClient};
+use zero_cli::service::{create_extrinsic, FullClient};
 use zero_runtime::{constants::currency::*, BalancesCall};
 use sc_block_builder::{BlockBuilderProvider, BuiltBlock, RecordProof};
 use sc_client_api::execution_extensions::ExecutionStrategies;
 use sc_consensus::{
 	block_import::{BlockImportParams, ForkChoiceStrategy},
-	BlockImport, StateAction,
+	StateAction,
 };
 use sc_service::{
 	config::{
@@ -43,7 +43,7 @@ use sp_runtime::{
 };
 use tokio::runtime::Handle;
 
-fn new_node(tokio_handle: Handle) -> node_cli::service::NewFullBase {
+fn new_node(tokio_handle: Handle) -> zero_cli::service::NewFullBase {
 	let base_path = BasePath::new_temp_dir()
 		.expect("getting the base path of a temporary path doesn't fail; qed");
 	let root = base_path.path().to_path_buf();
@@ -55,7 +55,7 @@ fn new_node(tokio_handle: Handle) -> node_cli::service::NewFullBase {
 		None,
 	);
 
-	let spec = Box::new(node_cli::chain_spec::development_config());
+	let spec = Box::new(zero_cli::chain_spec::development_config());
 
 	// NOTE: We enforce the use of the WASM runtime to benchmark block production using WASM.
 	let execution_strategy = sc_client_api::ExecutionStrategy::AlwaysWasm;
@@ -110,7 +110,7 @@ fn new_node(tokio_handle: Handle) -> node_cli::service::NewFullBase {
 		wasm_runtime_overrides: None,
 	};
 
-	node_cli::service::new_full_base(config, |_, _| ()).expect("creating a full node doesn't fail")
+	zero_cli::service::new_full_base(config, |_, _| ()).expect("creating a full node doesn't fail")
 }
 
 fn extrinsic_set_time(now: u64) -> OpaqueExtrinsic {

--- a/bin/zero/cli/benches/transaction_pool.rs
+++ b/bin/zero/cli/benches/transaction_pool.rs
@@ -18,7 +18,7 @@
 
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion, Throughput};
 use futures::{future, StreamExt};
-use node_cli::service::{create_extrinsic, fetch_nonce, FullClient, TransactionPool};
+use zero_cli::service::{create_extrinsic, fetch_nonce, FullClient, TransactionPool};
 use node_primitives::AccountId;
 use zero_runtime::{constants::currency::*, BalancesCall, SudoCall};
 use sc_client_api::execution_extensions::ExecutionStrategies;
@@ -36,7 +36,7 @@ use sp_keyring::Sr25519Keyring;
 use sp_runtime::{generic::BlockId, OpaqueExtrinsic};
 use tokio::runtime::Handle;
 
-fn new_node(tokio_handle: Handle) -> node_cli::service::NewFullBase {
+fn new_node(tokio_handle: Handle) -> zero_cli::service::NewFullBase {
 	let base_path = BasePath::new_temp_dir().expect("Creates base path");
 	let root = base_path.path().to_path_buf();
 
@@ -47,7 +47,7 @@ fn new_node(tokio_handle: Handle) -> node_cli::service::NewFullBase {
 		None,
 	);
 
-	let spec = Box::new(node_cli::chain_spec::development_config());
+	let spec = Box::new(zero_cli::chain_spec::development_config());
 
 	let config = Configuration {
 		impl_name: "BenchmarkImpl".into(),
@@ -102,7 +102,7 @@ fn new_node(tokio_handle: Handle) -> node_cli::service::NewFullBase {
 		wasm_runtime_overrides: None,
 	};
 
-	node_cli::service::new_full_base(config, |_, _| ()).expect("Creates node")
+	zero_cli::service::new_full_base(config, |_, _| ()).expect("Creates node")
 }
 
 fn create_accounts(num: usize) -> Vec<sr25519::Pair> {

--- a/makefile
+++ b/makefile
@@ -7,7 +7,15 @@ test:
 test-mod:
 	cargo +nightly test -p $(mod)
 
-# release
+# build for parachain
+parachain-build:
+	cargo build --release --features parachain
+parachain-run:
+	./target/release/subzero --tmp --name local-collator --collator
+parachain-purge:
+	./target/release/subzero --collator purge-chain -y
+
+# release standalone
 
 build:
 	cargo build --release


### PR DESCRIPTION
idea was to build docker for parachain testing. well.

- updated path refs and package names
- unsure about benches
- adding additional dockerfiles for cross platform build
  - x86_64 to build on m1 (tbd)
- eventually moving all non native modules into a folder like vendors or modules (tbd):
  - orml
  - gamedao
  - zero 