### PR TITLE
Enable cross-chain token transfers

### DIFF
--- a/bin/zero-parachain/node/Cargo.toml
+++ b/bin/zero-parachain/node/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "subzero-parachain-node"
 version = "3.1.61"
-authors = ["Anonymous"]
-description = "A new Cumulus FRAME-based Substrate Node, ready for hacking together a parachain."
-license = "Unlicense"
-homepage = "https://substrate.io"
-repository = "https://github.com/paritytech/cumulus/"
+authors = ["ZERO <play@zero.io>"]
+description = "A substrate node for video games and beyond."
+license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
+homepage = "https://zero.io"
+repository = "https://github.com/playzero/zero-network/"
 edition = "2021"
 build = "build.rs"
 

--- a/bin/zero-parachain/node/src/chain_spec.rs
+++ b/bin/zero-parachain/node/src/chain_spec.rs
@@ -225,6 +225,7 @@ fn testnet_genesis(
 		council: Default::default(),
 		treasury: Default::default(),
 		tokens: Default::default(),
-		control: Default::default()
+		control: Default::default(),
+		asset_registry: Default::default(),
 	}
 }

--- a/bin/zero-parachain/runtime/Cargo.toml
+++ b/bin/zero-parachain/runtime/Cargo.toml
@@ -80,9 +80,13 @@ parachain-info = { git = 'https://github.com/paritytech/cumulus', branch = 'polk
 primitives = { version = "2.0.0", package = "zero-primitives", default-features = false, path = "../../../modules/primitives" }
 module-asset-registry = { path = "../../../modules/asset-registry", default-features = false }
 
-orml-tokens = { path = "../../../modules/orml/tokens", default-features = false }
-orml-traits = { path = "../../../modules/orml/traits", default-features = false }
-orml-currencies = { path = "../../../modules/orml/currencies", default-features = false }
+orml-currencies = { path = "../../../orml/currencies", default-features = false }
+orml-tokens = { path = "../../../orml/tokens", default-features = false }
+orml-traits = { path = "../../../orml/traits", default-features = false }
+orml-unknown-tokens = { path = "../../../orml/unknown-tokens", default-features = false }
+orml-xcm = { path = "../../../orml/xcm", default-features = false }
+orml-xcm-support = { path = "../../../orml/xcm-support", default-features = false }
+orml-xtokens = { path = "../../../orml/xtokens", default-features = false }
 
 gamedao-traits = { path = "../../../modules/gamedao-protocol/traits", default-features = false }
 gamedao-flow = { path = "../../../modules/gamedao-protocol/flow", default-features = false }
@@ -148,9 +152,13 @@ std = [
 	"primitives/std",
 	"module-asset-registry/std",
 
-	"orml-tokens/std",
 	"orml-currencies/std",
+	"orml-tokens/std",
 	"orml-traits/std",
+	"orml-unknown-tokens/std",
+	"orml-xcm-support/std",
+	"orml-xcm/std",
+	"orml-xtokens/std",
 
 	"gamedao-sense/std",
 	"gamedao-traits/std",

--- a/bin/zero-parachain/runtime/src/xcm_config.rs
+++ b/bin/zero-parachain/runtime/src/xcm_config.rs
@@ -1,11 +1,14 @@
 use super::{
-	AccountId, Balances, Call, Event, Origin, ParachainInfo, ParachainSystem, PolkadotXcm, Runtime,
-	WeightToFee, XcmpQueue,
+	AssetIdMapping, AssetIdMaps, AccountId, Balance, Balances, Call, Convert,
+	CurrencyId, Currencies, Event, Origin, ParachainInfo,
+	ParachainSystem, PolkadotXcm, Runtime, TreasuryAccountId,
+	UnknownTokens, WeightToFee, XcmpQueue
 };
+use codec::{Decode, Encode};
 use core::marker::PhantomData;
 use frame_support::{
 	log, match_types, parameter_types,
-	traits::{Everything, Nothing},
+	traits::{Everything, Get, Nothing},
 	weights::Weight,
 };
 use pallet_xcm::XcmPassthrough;
@@ -13,17 +16,20 @@ use polkadot_parachain::primitives::Sibling;
 use polkadot_runtime_common::impls::ToAuthor;
 use xcm::latest::prelude::*;
 use xcm_builder::{
-	AccountId32Aliases, AllowTopLevelPaidExecutionFrom, AllowUnpaidExecutionFrom, CurrencyAdapter,
+	AccountId32Aliases, AllowTopLevelPaidExecutionFrom, AllowUnpaidExecutionFrom,
 	EnsureXcmOrigin, FixedWeightBounds, IsConcrete, LocationInverter, NativeAsset, ParentIsPreset,
 	RelayChainAsNative, SiblingParachainAsNative, SiblingParachainConvertsVia,
 	SignedAccountId32AsNative, SignedToAccountId32, SovereignSignedViaLocation, TakeWeightCredit,
 	UsingComponents,
 };
 use xcm_executor::{traits::ShouldExecute, XcmExecutor};
+use orml_traits::{location::AbsoluteReserveProvider, parameter_type_with_key};
+use orml_xcm_support::{DepositToAlternative, IsNativeConcrete, MultiCurrencyAdapter};
+
 
 parameter_types! {
 	pub const RelayLocation: MultiLocation = MultiLocation::parent();
-	pub const RelayNetwork: NetworkId = NetworkId::Any;
+	pub const RelayNetwork: NetworkId = NetworkId::Polkadot;
 	pub RelayChainOrigin: Origin = cumulus_pallet_xcm::Origin::Relay.into();
 	pub Ancestry: MultiLocation = Parachain(ParachainInfo::parachain_id().into()).into();
 }
@@ -41,17 +47,15 @@ pub type LocationToAccountId = (
 );
 
 /// Means for transacting assets on this chain.
-pub type LocalAssetTransactor = CurrencyAdapter<
-	// Use this currency:
-	Balances,
-	// Use this currency when it is a fungible asset matching the given location or name:
-	IsConcrete<RelayLocation>,
-	// Do a simple punn to convert an AccountId32 MultiLocation into a native chain account ID:
-	LocationToAccountId,
-	// Our chain's account ID type (we can't get away without mentioning it explicitly):
+pub type LocalAssetTransactor = MultiCurrencyAdapter<
+	Currencies,
+	UnknownTokens,
+	IsNativeConcrete<CurrencyId, CurrencyIdConvert>,
 	AccountId,
-	// We don't track any teleports.
-	(),
+	LocationToAccountId,
+	CurrencyId,
+	CurrencyIdConvert,
+	DepositToAlternative<TreasuryAccountId, Currencies, CurrencyId, AccountId, Balance>,
 >;
 
 /// This is the type we use to convert an (incoming) XCM origin into a local `Origin` instance,
@@ -218,4 +222,127 @@ impl pallet_xcm::Config for Runtime {
 impl cumulus_pallet_xcm::Config for Runtime {
 	type Event = Event;
 	type XcmExecutor = XcmExecutor<XcmConfig>;
+}
+
+fn native_currency_location(id: CurrencyId) -> MultiLocation {
+	MultiLocation::new(1, X2(Parachain(ParachainInfo::get().into()), GeneralKey(id.encode())))
+}
+
+pub struct CurrencyIdConvert;
+impl Convert<CurrencyId, Option<MultiLocation>> for CurrencyIdConvert {
+	fn convert(id: CurrencyId) -> Option<MultiLocation> {
+		use crate::CurrencyId::Token;
+		use primitives::TokenSymbol::*;
+		match id {
+			Token(DOT) => Some(MultiLocation::parent()),
+			Token(ZERO) | Token(GAME) | Token(PLAY) => Some(native_currency_location(id)),
+			CurrencyId::ForeignAsset(foreign_asset_id) => AssetIdMaps::<Runtime>::get_multi_location(foreign_asset_id),
+			_ => None,
+		}
+	}
+}
+impl Convert<MultiLocation, Option<CurrencyId>> for CurrencyIdConvert {
+	fn convert(location: MultiLocation) -> Option<CurrencyId> {
+		use crate::CurrencyId::Token;
+		use primitives::TokenSymbol::*;
+
+		if location == MultiLocation::parent() {
+			return Some(Token(DOT));
+		}
+
+		if let Some(currency_id) = AssetIdMaps::<Runtime>::get_currency_id(location.clone()) {
+			return Some(currency_id);
+		}
+
+		match location {
+			MultiLocation {
+				parents,
+				interior: X2(Parachain(para_id), GeneralKey(key)),
+			} if parents == 1 => {
+				match (para_id, &key[..]) {
+					(id, key) if id == u32::from(ParachainInfo::get()) => {
+						if let Ok(currency_id) = CurrencyId::decode(&mut &*key) {
+							// check `currency_id` is cross-chain asset
+							match currency_id {
+								Token(ZERO) | Token(GAME) | Token(PLAY) => Some(currency_id),
+								_ => None,
+							}
+						} else {
+							// invalid general key
+							None
+						}
+					}
+					_ => None,
+				}
+			}
+			// adapt for re-anchor canonical location: https://github.com/paritytech/polkadot/pull/4470
+			MultiLocation {
+				parents: 0,
+				interior: X1(GeneralKey(key)),
+			} => {
+				let key = &key[..];
+				let currency_id = CurrencyId::decode(&mut &*key).ok()?;
+				match currency_id {
+					Token(ZERO) | Token(GAME) | Token(PLAY) => Some(currency_id),
+					_ => None,
+				}
+			}
+			_ => None,
+		}
+	}
+}
+impl Convert<MultiAsset, Option<CurrencyId>> for CurrencyIdConvert {
+	fn convert(asset: MultiAsset) -> Option<CurrencyId> {
+		if let MultiAsset {
+			id: Concrete(location), ..
+		} = asset
+		{
+			Self::convert(location)
+		} else {
+			None
+		}
+	}
+}
+
+parameter_types! {
+	pub SelfLocation: MultiLocation = MultiLocation::new(1, X1(Parachain(ParachainInfo::get().into())));
+}
+
+pub struct AccountIdToMultiLocation;
+impl Convert<AccountId, MultiLocation> for AccountIdToMultiLocation {
+	fn convert(account: AccountId) -> MultiLocation {
+		X1(AccountId32 {
+			network: NetworkId::Any,
+			id: account.into(),
+		})
+		.into()
+	}
+}
+
+parameter_types! {
+	pub const BaseXcmWeight: Weight = 100_000_000;
+	pub const MaxAssetsForTransfer: usize = 2;
+}
+
+parameter_type_with_key! {
+	pub ParachainMinFee: |_location: MultiLocation| -> Option<u128> {
+		None
+	};
+}
+
+impl orml_xtokens::Config for Runtime {
+	type Event = Event;
+	type Balance = Balance;
+	type CurrencyId = CurrencyId;
+	type CurrencyIdConvert = CurrencyIdConvert;
+	type AccountIdToMultiLocation = AccountIdToMultiLocation;
+	type SelfLocation = SelfLocation;
+	type XcmExecutor = XcmExecutor<XcmConfig>;
+	type Weigher = FixedWeightBounds<UnitWeightCost, Call, MaxInstructions>;
+	type BaseXcmWeight = BaseXcmWeight;
+	type LocationInverter = LocationInverter<Ancestry>;
+	type MaxAssetsForTransfer = MaxAssetsForTransfer;
+	type MinXcmFee = ParachainMinFee;
+	type MultiLocationsFilter = Everything;
+	type ReserveProvider = AbsoluteReserveProvider;
 }

--- a/modules/primitives/src/currency.rs
+++ b/modules/primitives/src/currency.rs
@@ -136,11 +136,23 @@ create_currency_id! {
 	}
 }
 
+pub type ForeignAssetId = u16;
+
 pub trait TokenInfo {
 	fn currency_id(&self) -> Option<u8>;
 	fn name(&self) -> Option<&str>;
 	fn symbol(&self) -> Option<&str>;
 	fn decimals(&self) -> Option<u8>;
+}
+
+/// A mapping between AssetId and AssetMetadata.
+pub trait AssetIdMapping<ForeignAssetId, MultiLocation, AssetMetadata> {
+	/// Returns the AssetMetadata associated with a given `AssetIds`.
+	fn get_asset_metadata(asset_ids: AssetIds) -> Option<AssetMetadata>;
+	/// Returns the MultiLocation associated with a given ForeignAssetId.
+	fn get_multi_location(foreign_asset_id: ForeignAssetId) -> Option<MultiLocation>;
+	/// Returns the CurrencyId associated with a given MultiLocation.
+	fn get_currency_id(multi_location: MultiLocation) -> Option<CurrencyId>;
 }
 
 
@@ -149,6 +161,7 @@ pub trait TokenInfo {
 #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 pub enum CurrencyId {
 	Token(TokenSymbol),
+	ForeignAsset(ForeignAssetId)
 }
 
 impl CurrencyId {
@@ -164,11 +177,13 @@ impl CurrencyId {
 #[repr(u8)]
 pub enum CurrencyIdType {
 	Token = 1, // 0 is prefix of precompile and predeploy
+	ForeignAsset,
 }
 
 #[derive(Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, TypeInfo)]
 pub enum AssetIds {
 	NativeAssetId(CurrencyId),
+	ForeignAssetId(ForeignAssetId),
 }
 
 #[derive(Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, TypeInfo)]

--- a/modules/primitives/src/lib.rs
+++ b/modules/primitives/src/lib.rs
@@ -25,10 +25,10 @@ use sp_runtime::{
 	traits::{BlakeTwo256, IdentifyAccount, Verify},
 	MultiSignature, OpaqueExtrinsic, RuntimeDebug
 };
-use sp_std::{prelude::*, convert::TryFrom};
+use sp_std::{prelude::*};
 
 pub mod currency;
-pub use currency::{CurrencyId, TokenSymbol, TokenInfo};
+pub use currency::{AssetIdMapping, CurrencyId, TokenSymbol, TokenInfo};
 
 /// An index to a block.
 pub type BlockNumber = u32;


### PR DESCRIPTION
* Extends `asset-registry` pallet to work with foreign assets
* Setups XCM pallets and modules to communicate between parachains
* Adds ORML `xtokens` pallet for cross-chain token transfers