### PR TITLE
Drop dependabot resolver

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "cargo"
-    directory: "/"
-    labels: ["A2-insubstantial", "B0-silent", "C1-low 📌"]
-    schedule:
-      interval: "daily"


### PR DESCRIPTION
Disables `dependabot` by dropping it's config file.