### PR TITLE
Update benchmarks to properly work with new pallets

### DIFF
--- a/bin/subzero/runtime/Cargo.toml
+++ b/bin/subzero/runtime/Cargo.toml
@@ -214,6 +214,7 @@ runtime-benchmarks = [
 	"pallet-identity/runtime-benchmarks",
 	"pallet-treasury/runtime-benchmarks",
 	"pallet-timestamp/runtime-benchmarks",
+	"pallet-uniques/runtime-benchmarks",
 	"pallet-xcm/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
 	"xcm-builder/runtime-benchmarks",

--- a/bin/subzero/runtime/src/lib.rs
+++ b/bin/subzero/runtime/src/lib.rs
@@ -1159,6 +1159,10 @@ mod benches {
 		[pallet_timestamp, Timestamp]
 		[pallet_collator_selection, CollatorSelection]
 		[cumulus_pallet_xcmp_queue, XcmpQueue]
+		[gamedao_flow, Flow]
+		[gamedao_sense, Sense]
+		[gamedao_control, Control]
+		[gamedao_signal, Signal]
 	);
 }
 

--- a/bin/zero/runtime/Cargo.toml
+++ b/bin/zero/runtime/Cargo.toml
@@ -203,6 +203,7 @@ runtime-benchmarks = [
 	"pallet-identity/runtime-benchmarks",
 	"pallet-treasury/runtime-benchmarks",
 	"pallet-timestamp/runtime-benchmarks",
+	"pallet-uniques/runtime-benchmarks",
 	"pallet-xcm/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
 	"xcm-builder/runtime-benchmarks",


### PR DESCRIPTION
Fixes:
- error while building with benchmarking flag for unique pallet
- enables GameDAO pallets for benchmarks generation