### PR TITLE
feat: bump versions, update gamedao

### DIFF
--- a/.docker/subzero-dev.Dockerfile
+++ b/.docker/subzero-dev.Dockerfile
@@ -2,9 +2,9 @@
 # because they're too often out of date,
 # preventing them from being used to build subzero/Polkadot.
 
+# FROM phusion/baseimage:jammy-1.0.1 as baseimage
 FROM phusion/baseimage:focal-1.2.0 as baseimage
 ENV DEBIAN_FRONTEND=noninteractive
-
 
 RUN apt-get update && \
 	apt-get dist-upgrade -y -o Dpkg::Options::="--force-confold" && \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,7 +84,7 @@ dependencies = [
 
 [[package]]
 name = "alphaville"
-version = "3.2.62"
+version = "3.2.67"
 dependencies = [
  "alphaville-runtime",
  "assert_cmd",
@@ -169,7 +169,7 @@ dependencies = [
 
 [[package]]
 name = "alphaville-runtime"
-version = "3.2.62"
+version = "3.2.67"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -179,6 +179,7 @@ dependencies = [
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
  "frame-try-runtime",
+ "gamedao-battlepass",
  "gamedao-control",
  "gamedao-flow",
  "gamedao-sense",
@@ -3058,6 +3059,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
 dependencies = [
  "byteorder",
+]
+
+[[package]]
+name = "gamedao-battlepass"
+version = "1.2.0"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-support-test",
+ "frame-system",
+ "gamedao-control",
+ "gamedao-traits",
+ "orml-currencies",
+ "orml-tokens",
+ "orml-traits",
+ "pallet-balances",
+ "pallet-rmrk-core",
+ "pallet-uniques",
+ "parity-scale-codec",
+ "rand 0.8.5",
+ "rmrk-traits",
+ "scale-info",
+ "serde",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+ "sp-storage",
 ]
 
 [[package]]
@@ -11599,7 +11628,7 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "subzero-dev-node"
-version = "3.2.63"
+version = "3.2.67"
 dependencies = [
  "clap 3.2.17",
  "cumulus-client-cli",
@@ -11670,7 +11699,7 @@ dependencies = [
 
 [[package]]
 name = "subzero-dev-runtime"
-version = "3.2.63"
+version = "3.2.67"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-dmp-queue",
@@ -11688,6 +11717,7 @@ dependencies = [
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
  "frame-try-runtime",
+ "gamedao-battlepass",
  "gamedao-control",
  "gamedao-flow",
  "gamedao-sense",

--- a/bin/alphaville/cli/Cargo.toml
+++ b/bin/alphaville/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alphaville"
-version = "3.2.62"
+version = "3.2.67"
 authors = ["ZERO <play@zero.io>"]
 description = "build video games and beyond"
 build = "build.rs"

--- a/bin/alphaville/runtime/Cargo.toml
+++ b/bin/alphaville/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alphaville-runtime"
-version = "3.2.62"
+version = "3.2.67"
 authors = ["ZERO <play@zero.io>"]
 edition = "2021"
 build = "build.rs"

--- a/bin/alphaville/runtime/src/lib.rs
+++ b/bin/alphaville/runtime/src/lib.rs
@@ -139,7 +139,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to 0. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 62,
+	spec_version: 67,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/bin/subzero-dev/node/Cargo.toml
+++ b/bin/subzero-dev/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subzero-dev-node"
-version = "3.2.66"
+version = "3.2.67"
 authors = ["ZERO <play@zero.io>"]
 description = "A substrate node for video games and beyond."
 license = "GPL-3.0-or-later WITH Classpath-exception-2.0"

--- a/bin/subzero-dev/runtime/Cargo.toml
+++ b/bin/subzero-dev/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subzero-dev-runtime"
-version = "3.2.66"
+version = "3.2.67"
 authors = ["ZERO <play@zero.io>"]
 license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 homepage = "https://zero.io"

--- a/bin/subzero-dev/runtime/src/lib.rs
+++ b/bin/subzero-dev/runtime/src/lib.rs
@@ -160,7 +160,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("subzero"),
 	impl_name: create_runtime_str!("dev"),
 	authoring_version: 75,
-	spec_version: 66,
+	spec_version: 67,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/makefile
+++ b/makefile
@@ -1,16 +1,16 @@
-# build alphaville docker
-
+# alphaville docker
 alphaville-docker:
 	docker build -t playzero/alphaville:local -f .docker/alphaville.Dockerfile .
-
 alphaville-run:
 	docker run \
 		-p 9933:9933 -p 9944:9944 -p 30333:30333 \
 		playzero/alphaville:local /usr/local/bin/alphaville \
 		--dev --name alphaville --ws-external \
 		--rpc-external --rpc-cors all --rpc-methods unsafe
+# build subzero-dev docker
+dev-docker-build:
+	docker build -t playzero/subzero:dev -f .docker/subzero-dev.Dockerfile .
 
-#
 #
 #
 


### PR DESCRIPTION
- [x] bump versions in alphaville, subzero-dev to 3.2.67
- [x] add current gamedao-protocol
  - [x] fix access control for prime approving members
  - [x] update battlepass